### PR TITLE
Functional avatar width/height control...

### DIFF
--- a/root/includes/ucp/ucp_dynamo.php
+++ b/root/includes/ucp/ucp_dynamo.php
@@ -189,8 +189,8 @@ class ucp_dynamo
 					$sql_array = array(
 						'user_avatar' 			=> generate_board_url() . '/' . $avatar_filename,
 						'user_avatar_type'		=> 2, // means remote i guess
-						'user_avatar_width'		=> imagesx($first_image), // maybe this should be set to something ...
-						'user_avatar_height'	=> imagesy($first_image)
+						'user_avatar_width'		=> $config['dynamo_width'], // maybe this should be set to something ...
+						'user_avatar_height'	=> $config['dynamo_height'],
 					);
 
 					$sql = "UPDATE " . USERS_TABLE . "


### PR DESCRIPTION
For some reason it chops it the far bottom and far right sections at 100x120 and then just expands/zooms it to the correct size(this could be one of many other mods I have running or a phpbb max avatar size, but it worked fine before...?)? But this is at least the start of getting the code working properly.

Tested with several different widths/heights on the profile and viewtopic pages, works like a charm(my memberlist is modded so I can't test it there).
